### PR TITLE
修复 android 11以上不能正常使用以及正常打开企业微信误杀

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,4 +102,9 @@
         <!--        </service>-->
     </application>
 
+    <!--  Android 11以上权限限制，加入这个才能取到launchIntent  -->
+    <queries>
+        <package android:name="com.tencent.wework" />
+    </queries>
+
 </manifest>

--- a/app/src/main/java/cn/martinkay/autocheckinplugin/MainActivity.kt
+++ b/app/src/main/java/cn/martinkay/autocheckinplugin/MainActivity.kt
@@ -692,6 +692,7 @@ class MainActivity : AppCompatActivity() {
                 .show()
             return
         }
+        SharePrefHelper.putLong(SIGN_OPEN_INTENT_START_TIME, System.currentTimeMillis())
         startActivity(intent)
     }
 

--- a/app/src/main/java/cn/martinkay/autocheckinplugin/SharePrefHelper.kt
+++ b/app/src/main/java/cn/martinkay/autocheckinplugin/SharePrefHelper.kt
@@ -26,6 +26,9 @@ const val SIGN_TASK_MORNING_OFF_WORK_START_TIME = "sign_task_morning_off_work_st
 const val SIGN_TASK_AFTERNOON_START_WORK_START_TIME = "sign_task_start_work_start_time"
 
 const val SIGN_TASK_AFTERNOON_OFF_WORK_START_TIME = "sign_task_stop_work_start_time"
+
+const val SIGN_OPEN_INTENT_START_TIME = "sign_open_intent_start_time"
+
 object SharePrefHelper {
     private var mShare: SharedPreferences? = null
 
@@ -52,6 +55,16 @@ object SharePrefHelper {
 
     fun getString(key: String, default: String?): String {
         return getSharePref().getString(key, default).toString()
+    }
+
+    fun putLong(key: String, value: Long) {
+        val editor = getSharePref().edit()
+        editor.putLong(key, value)
+        editor.apply()
+    }
+
+    fun getLong(key: String, default: Long): Long {
+        return getSharePref().getLong(key, default)
     }
 
     fun putBoolean(key: String, value: Boolean = false) {

--- a/app/src/main/java/cn/martinkay/autocheckinplugin/broad/AlarmReceiver.java
+++ b/app/src/main/java/cn/martinkay/autocheckinplugin/broad/AlarmReceiver.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.PowerManager;
 import android.util.Log;
 
+import cn.martinkay.autocheckinplugin.SharePrefHelper;
 import com.topjohnwu.superuser.Shell;
 
 import java.util.ArrayList;
@@ -25,6 +26,8 @@ import cn.martinkay.autocheckinplugin.utils.AlarManagerUtil;
 import cn.martinkay.autocheckinplugin.utils.HShizuku;
 import kotlin.Pair;
 import rikka.shizuku.Shizuku;
+
+import static cn.martinkay.autocheckinplugin.SharePrefHelperKt.SIGN_OPEN_INTENT_START_TIME;
 
 public class AlarmReceiver extends BroadcastReceiver {
     Random random = new Random();
@@ -82,6 +85,7 @@ public class AlarmReceiver extends BroadcastReceiver {
             }
             Intent launchIntentForPackage = context.getPackageManager().getLaunchIntentForPackage(Constant.getActiveApp().getPackageName());
             if (launchIntentForPackage != null) {
+                SharePrefHelper.INSTANCE.putLong(SIGN_OPEN_INTENT_START_TIME, System.currentTimeMillis());
                 context.startActivity(launchIntentForPackage);
                 Log.i("ContentValues", "启动打卡程序2");
             }

--- a/app/src/main/java/cn/martinkay/autocheckinplugin/handler/pageprocessor/weixin/CompleteProcessor.java
+++ b/app/src/main/java/cn/martinkay/autocheckinplugin/handler/pageprocessor/weixin/CompleteProcessor.java
@@ -3,9 +3,12 @@ package cn.martinkay.autocheckinplugin.handler.pageprocessor.weixin;
 import android.util.Log;
 import android.view.accessibility.AccessibilityEvent;
 
+import cn.martinkay.autocheckinplugin.SharePrefHelper;
 import cn.martinkay.autocheckinplugin.handler.pageprocessor.BasePageProcessor;
 import cn.martinkay.autocheckinplugin.service.MyAccessibilityService;
 import cn.martinkay.autocheckinplugin.util.AccessibilityHelper;
+
+import static cn.martinkay.autocheckinplugin.SharePrefHelperKt.SIGN_OPEN_INTENT_START_TIME;
 
 public class CompleteProcessor extends BasePageProcessor {
     @Override
@@ -39,7 +42,12 @@ public class CompleteProcessor extends BasePageProcessor {
 
     @Override
     public void processPage(AccessibilityEvent event, MyAccessibilityService myAccessibilityService) {
-        Log.i("Weixin-SigninPageProcessor", "拦截重复打卡");
+        long startTime = SharePrefHelper.INSTANCE.getLong(SIGN_OPEN_INTENT_START_TIME, 0);
+        if ((System.currentTimeMillis() - startTime) > 5_000) {
+            Log.i("Weixin-SigninPageProcessor", "不是由程序打开的，忽略");
+            return;
+        }
+        Log.w("Weixin-SigninPageProcessor", "拦截重复打卡");
         myAccessibilityService.clickHomeKey();
         myAccessibilityService.closeApp("com.tencent.wework");
         myAccessibilityService.autoLock();


### PR DESCRIPTION
1. android 11以上提示企业微信未安装，实际是 android 11以上对权限进一步收窄
2. 用户手动打开企业微信后，触发无障碍自动关闭程序，属于误杀操作