### PR TITLE
fix: Android 12 以上使用前台服务需要添加权限

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.GET_TASKS" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <!--  豁免白名单  -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />


### PR DESCRIPTION
Android 12 (API 31) 以上需要添加权限 `android.permission.FOREGROUND_SERVICE_SPECIAL_USE` 才能使用前台服务